### PR TITLE
Correct BCI for NewArray and NewMultiArray Statements and Fix DaCapo

### DIFF
--- a/src/analyser/StaticAnalyser.java
+++ b/src/analyser/StaticAnalyser.java
@@ -40,6 +40,14 @@ public class StaticAnalyser extends BodyTransformer {
 //			verboseFlag = true;
 //			System.out.println(body.getMethod().toString());
 //		}
+		// System.out.println("func: "+body.getMethod().toString());
+		
+		// if (true) // Ignore Library Methods.
+		// 	return;
+		// if (body.getMethod().toString().compareTo("<jdk.internal.org.objectweb.asm.Label: void visitSubroutine(jdk.internal.org.objectweb.asm.Label,long,int)>") == 0)
+		// {
+		// 	return;
+		// }
 		String path = Scene.v().getSootClassPath();
 //		System.out.println(path);
 //		System.out.println("Package:"+body.getMethod().getDeclaringClass().getJavaPackageName());
@@ -181,6 +189,7 @@ public class StaticAnalyser extends BodyTransformer {
 		PointsToGraph ptg = elem.getValue().getOut();
 		ptgs.put(body.getMethod(), ptg);
 		summaries.put(body.getMethod(), summary);
+		// System.out.println("func: "+body.getMethod().toString());
 	}
 
 	/*

--- a/src/analyser/StaticAnalyser.java
+++ b/src/analyser/StaticAnalyser.java
@@ -15,16 +15,18 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.Map.Entry;
 
+import java.util.concurrent.ConcurrentHashMap;
+
 public class StaticAnalyser extends BodyTransformer {
-	public static HashMap<SootMethod, PointsToGraph> ptgs;
-	public static HashMap<SootMethod, HashMap<ObjectNode, EscapeStatus>> summaries;
+	public static Map<SootMethod, PointsToGraph> ptgs;
+	public static Map<SootMethod, HashMap<ObjectNode, EscapeStatus>> summaries;
 	public static LinkedHashMap<Body, Analysis> analysis;
 
 	public StaticAnalyser() {
 		super();
 		analysis = new LinkedHashMap<>();
-		ptgs = new HashMap<>();
-		summaries = new HashMap<>();
+		ptgs = new ConcurrentHashMap<>();
+		summaries = new ConcurrentHashMap<>();
 	}
 
 
@@ -40,7 +42,7 @@ public class StaticAnalyser extends BodyTransformer {
 //			verboseFlag = true;
 //			System.out.println(body.getMethod().toString());
 //		}
-		// System.out.println("func: "+body.getMethod().toString());
+		// System.out.println("func: "+body.getMethod().toString() +" "+ body.getMethod().isJavaLibraryMethod());
 		
 		// if (true) // Ignore Library Methods.
 		// 	return;
@@ -198,7 +200,7 @@ public class StaticAnalyser extends BodyTransformer {
 	 * changes on.
 	 */
 
-	public void apply(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	public void apply(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		if (u instanceof JAssignStmt) {
 			JAssignStmtHandler.handle(u, ptg, summary);
 		} else if (u instanceof JIdentityStmt) {

--- a/src/es/ConditionalValue.java
+++ b/src/es/ConditionalValue.java
@@ -108,7 +108,6 @@ public class ConditionalValue extends EscapeState {
 			}
 		} catch (Exception e2) {
 			System.out.println("Comparing:" + this.toString() + " with " + e.toString() + " at depth " + depth);
-			// throw new IllegalArgumentException();
 			throw e2;
 		}
 		return true;

--- a/src/es/ConditionalValue.java
+++ b/src/es/ConditionalValue.java
@@ -102,13 +102,14 @@ public class ConditionalValue extends EscapeState {
 			if (this.fieldList != null) {
 				if (e.fieldList == null) return false;
 				if (this.fieldList != null && this.fieldList.size() != depth) return false;
-				for (int i = 0; i < depth; i++) {
+				for (int i = 0; i < depth && i< e.fieldList.size() ; i++) {
 					if (!this.fieldList.get(i).equals(e.fieldList.get(i))) return false;
 				}
 			}
 		} catch (Exception e2) {
 			System.out.println("Comparing:" + this.toString() + " with " + e.toString() + " at depth " + depth);
-			throw new IllegalArgumentException();
+			// throw new IllegalArgumentException();
+			throw e2;
 		}
 		return true;
 	}

--- a/src/handlers/JAssignStmt/CopyStmt.java
+++ b/src/handlers/JAssignStmt/CopyStmt.java
@@ -13,7 +13,7 @@ import soot.jimple.internal.JAssignStmt;
 import soot.jimple.internal.JCastExpr;
 import utils.AnalysisError;
 
-import java.util.HashMap;
+import java.util.Map;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -22,7 +22,7 @@ import java.util.Set;
  * The sanitation check to ensure the appropriate types has been skipped for performance.
  */
 public class CopyStmt {
-	public static void handle(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	public static void handle(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		Value rhs = ((JAssignStmt)u).getRightOp();
 		if(rhs instanceof Local){
 			CopyStmt(u, ptg, summary);
@@ -31,7 +31,7 @@ public class CopyStmt {
 		} else AnalysisError.unidentifiedAssignStmtCase(u);
 	}
 
-	private static void rhsCastExpr(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void rhsCastExpr(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		// TODO: put a check for cast to a runnable class.
 		// a = (Cast?)b
 		Local lhs = (Local)((JAssignStmt)u).getLeftOp();
@@ -53,13 +53,13 @@ public class CopyStmt {
 		CopyStmtHelper(u, (Local) ((JAssignStmt) u).getLeftOp(), rhs, ptg, summary);
 	}
 
-	private static void CopyStmt(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void CopyStmt(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		Local lhs = (Local) ((JAssignStmt) u).getLeftOp();
 		Local rhs = (Local) ((JAssignStmt) u).getRightOp();
 		CopyStmtHelper(u, lhs, rhs, ptg, summary);
 	}
 
-	private static void CopyStmtHelper(Unit u, Local lhs, Local rhs, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void CopyStmtHelper(Unit u, Local lhs, Local rhs, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		Set<ObjectNode> ptSet = null;
 		if (ptg.vars.containsKey(rhs)) {
 			ptSet = (Set<ObjectNode>) ((HashSet<ObjectNode>) ptg.vars.get(rhs)).clone();

--- a/src/handlers/JAssignStmt/EraseStmt.java
+++ b/src/handlers/JAssignStmt/EraseStmt.java
@@ -11,7 +11,7 @@ import soot.Value;
 import soot.jimple.StaticFieldRef;
 import soot.jimple.internal.JAssignStmt;
 
-import java.util.HashMap;
+import java.util.Map;
 import java.util.HashSet;
 
 /*
@@ -19,7 +19,7 @@ import java.util.HashSet;
  * The sanitation check to ensure the appropriate types has been skipped for performance.
  */
 public class EraseStmt {
-	public static void handle(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	public static void handle(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		Value lhs = ((JAssignStmt) u).getLeftOp();
 		if (lhs instanceof StaticFieldRef) {
 			// Ignore - [Verified]

--- a/src/handlers/JAssignStmt/InvokeStmt.java
+++ b/src/handlers/JAssignStmt/InvokeStmt.java
@@ -17,14 +17,14 @@ import soot.jimple.internal.AbstractInvokeExpr;
 import soot.jimple.internal.JAssignStmt;
 import utils.getBCI;
 
-import java.util.HashMap;
+import java.util.Map;
 
 /*
  * Meant to be only called by JAssignStmtHandler.
  * The sanitation check to ensure the appropriate types has been skipped for performance.
  */
 public class InvokeStmt {
-	public static void handle(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	public static void handle(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		Local lhs = (Local) ((JAssignStmt) u).getLeftOp();
 		Value rhs = ((JAssignStmt) u).getRightOp();
 		AbstractInvokeExpr expr = (AbstractInvokeExpr) rhs;

--- a/src/handlers/JAssignStmt/JAssignStmtHandler.java
+++ b/src/handlers/JAssignStmt/JAssignStmtHandler.java
@@ -12,13 +12,13 @@ import utils.AnalysisError;
 import utils.getBCI;
 
 import java.security.InvalidParameterException;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
 public class JAssignStmtHandler {
-	public static void handle(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	public static void handle(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		{
 			/*
 			 * JAssignStmt Example:
@@ -42,7 +42,7 @@ public class JAssignStmtHandler {
 		}
 	}
 
-	private static void lhsIsLocal(Value rhs, Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void lhsIsLocal(Value rhs, Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		if (rhs instanceof AnyNewExpr) {
 			NewStmt.handle(u, ptg, summary);
 		} else if (rhs instanceof NullConstant) {
@@ -58,7 +58,7 @@ public class JAssignStmtHandler {
 		} else AnalysisError.unidentifiedAssignStmtCase(u);
 	}
 
-	private static void storeConstantToLocal(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void storeConstantToLocal(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		// TODO: ObjectFactory no longer has responsibility to figure out ObjectType
 		ObjectNode obj = ObjectFactory.getObj(u);
 		if (obj.type != ObjectType.internal) {

--- a/src/handlers/JAssignStmt/LoadStmt.java
+++ b/src/handlers/JAssignStmt/LoadStmt.java
@@ -17,7 +17,7 @@ import utils.AnalysisError;
 import utils.getBCI;
 
 import java.security.InvalidParameterException;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -27,7 +27,7 @@ import java.util.Set;
  * The sanitation check to ensure the appropriate types has been skipped for performance.
  */
 public class LoadStmt {
-	public static void handle(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	public static void handle(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		JAssignStmt stmt = (JAssignStmt) u;
 		Value rhs = stmt.getRightOp();
 		if (rhs instanceof StaticFieldRef) {
@@ -39,7 +39,7 @@ public class LoadStmt {
 		} else AnalysisError.unidentifiedAssignStmtCase(u);
 	}
 
-	private static void staticField(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void staticField(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		Local lhs = (Local) ((JAssignStmt) u).getLeftOp();
 		ObjectNode obj = new ObjectNode(getBCI.get(u), ObjectType.external);
 		EscapeStatus es = new EscapeStatus(Escape.getInstance());
@@ -51,7 +51,7 @@ public class LoadStmt {
 		summary.put(obj, es);
 	}
 
-	private static void instanceField(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void instanceField(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		JAssignStmt stmt = (JAssignStmt) u;
 		Local lhs = (Local) stmt.getLeftOp();
 		JInstanceFieldRef rhs = (JInstanceFieldRef) stmt.getRightOp();
@@ -110,7 +110,7 @@ public class LoadStmt {
 	 * ObjectType of the base, as in a case where the points-to set of the
 	 * base containing objects of both internal and external type.
 	 */
-	private static void rhsArrayRef(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void rhsArrayRef(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		Local lhs = (Local) ((JAssignStmt) u).getLeftOp();
 		Value rhs = ((JAssignStmt) u).getRightOp();
 		JArrayRef arrayRef = (JArrayRef) rhs;

--- a/src/handlers/JAssignStmt/NewStmt.java
+++ b/src/handlers/JAssignStmt/NewStmt.java
@@ -21,14 +21,14 @@ import utils.IsMultiThreadedClass;
 import utils.getBCI;
 
 import java.security.InvalidParameterException;
-import java.util.HashMap;
+import java.util.Map;
 
 /*
  * Meant to be only called by JAssignStmtHandler.
  * The sanitation check to ensure the appropriate types has been skipped for performance.
  */
 public class NewStmt {
-	public static void handle(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	public static void handle(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		Value rhs = ((JAssignStmt) u).getRightOp();
 		if (rhs instanceof JNewExpr) {
 			JNewStmt(u, ptg, summary);
@@ -40,7 +40,7 @@ public class NewStmt {
 	/*
 	 * Undoubtedly a new object creation. Object will be internal and ES will be does not escape.
 	 */
-	private static void JNewStmt(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void JNewStmt(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 
 		// check if rhs is runnable
 		Value rhs = ((JAssignStmt) u).getRightOp();
@@ -63,7 +63,7 @@ public class NewStmt {
 		if (!summary.containsKey(obj)) summary.put(obj, es);
 	}
 
-	private static void JNewArrayStmt(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void JNewArrayStmt(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		// check if rhs is runnable
 		Value rhs = ((JAssignStmt) u).getRightOp();
 		Value lhs = ((JAssignStmt) u).getLeftOp();

--- a/src/handlers/JAssignStmt/StoreStmt.java
+++ b/src/handlers/JAssignStmt/StoreStmt.java
@@ -18,7 +18,7 @@ import soot.jimple.internal.JAssignStmt;
 import soot.jimple.internal.JInstanceFieldRef;
 import utils.AnalysisError;
 
-import java.util.HashMap;
+import java.util.Map;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -29,7 +29,7 @@ import java.util.Set;
  * The sanitation check to ensure the appropriate types has been skipped for performance.
  */
 public class StoreStmt {
-	public static void handle(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	public static void handle(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		JAssignStmt stmt = (JAssignStmt) u;
 		Value lhs = stmt.getLeftOp();
 		Value rhs = stmt.getRightOp();
@@ -54,7 +54,7 @@ public class StoreStmt {
 		} else AnalysisError.unidentifiedAssignStmtCase(u);
 	}
 
-	private static void lhsIsJInstanceFieldRef(Value rhs, Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void lhsIsJInstanceFieldRef(Value rhs, Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		if (rhs instanceof StringConstant) {
 			storeStringConstantToInstanceFieldRefStmt(u, ptg, summary);
 		} else if (rhs instanceof NullConstant) {
@@ -78,7 +78,7 @@ public class StoreStmt {
 	 * 		es(rhs) U= es(object).field_name
 	 * }
 	 */
-	private static void storeStmt(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void storeStmt(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		// Store case
 		JInstanceFieldRef lhs = (JInstanceFieldRef) ((JAssignStmt) u).getLeftOp();
 		Local rhs = (Local) ((JAssignStmt) u).getRightOp();
@@ -99,11 +99,11 @@ public class StoreStmt {
 		ptg.propagateES((Local) lhs.getBase(), rhs, summary);
 	}
 
-	private static void StaticStoreStmt(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void StaticStoreStmt(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		ptg.cascadeEscape((Local) ((JAssignStmt) u).getRightOp(), summary);
 	}
 
-	private static void storeClassConstantToArrayRef(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void storeClassConstantToArrayRef(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		JArrayRef lhs = (JArrayRef) ((JAssignStmt) u).getLeftOp();
 		ObjectNode obj = ObjectFactory.getObj(u);
 		if (obj.type != ObjectType.internal) {
@@ -114,7 +114,7 @@ public class StoreStmt {
 		summary.put(obj, new EscapeStatus(Escape.getInstance()));
 	}
 
-	private static void storeStringConstantToInstanceFieldRefStmt(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void storeStringConstantToInstanceFieldRefStmt(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		JInstanceFieldRef lhs = (JInstanceFieldRef) ((JAssignStmt) u).getLeftOp();
 		ObjectNode obj = ObjectFactory.getObj(u);
 		if (obj.type != ObjectType.internal) {
@@ -136,7 +136,7 @@ public class StoreStmt {
 		summary.put(obj, es);
 	}
 
-	private static void storeStringConstantToArrayRefStmt(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void storeStringConstantToArrayRefStmt(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		JArrayRef lhs = (JArrayRef) ((JAssignStmt) u).getLeftOp();
 		ObjectNode obj = ObjectFactory.getObj(u);
 		if (obj.type != ObjectType.internal) {
@@ -153,14 +153,14 @@ public class StoreStmt {
 		summary.put(obj, es);
 	}
 
-	private static void lhsArrayRef(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void lhsArrayRef(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		JArrayRef lhs = (JArrayRef) ((JAssignStmt) u).getLeftOp();
 		Local rhs = (Local) ((JAssignStmt) u).getRightOp();
 		ptg.storeStmtArrayRef((Local) lhs.getBase(), rhs);
 		ptg.propagateES((Local) lhs.getBase(), rhs, summary);
 	}
 
-	private static void eraseFieldRefStmt(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	private static void eraseFieldRefStmt(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		if(AssignStmtHandler.STORE==UpdateType.WEAK) return;
 		JInstanceFieldRef lhs = (JInstanceFieldRef) ((JAssignStmt) u).getLeftOp();
 		if (!ptg.vars.containsKey(lhs.getBase())) return;

--- a/src/handlers/JReturnStmtHandler.java
+++ b/src/handlers/JReturnStmtHandler.java
@@ -10,10 +10,10 @@ import soot.Value;
 import soot.jimple.NullConstant;
 import soot.jimple.internal.JReturnStmt;
 
-import java.util.HashMap;
+import java.util.Map;
 
 public class JReturnStmtHandler {
-	public static void handle(Unit u, PointsToGraph ptg, HashMap<ObjectNode, EscapeStatus> summary) {
+	public static void handle(Unit u, PointsToGraph ptg, Map<ObjectNode, EscapeStatus> summary) {
 		Value op = ((JReturnStmt) u).getOp();
 		if (op instanceof NullConstant) return;
 			// TODO: is this correct?

--- a/src/main/GetSootArgs.java
+++ b/src/main/GetSootArgs.java
@@ -27,14 +27,16 @@ public class GetSootArgs {
 	private String[] dacapo(String[] args){
 		String dir = args[2] + "/out";
 		String refl_log = "reflection-log:" + dir + "/refl.log";
-		String cp = args[0] + "/jre/lib/rt.jar:" + args[0] + "/jre/lib/jce.jar:" + dir + ":" + args[2] + "/dacapo-9.12-MR1-bach.jar";
+		// String cp = args[0] + "/jre/lib/rt.jar:" + args[0] + "/jre/lib/jce.jar:" + dir + ":" + args[2] + "/dacapo-9.12-MR1-bach.jar";
+		String cp = dir + ":" + args[2] + "/dacapo-9.12-MR1-bach.jar";
 		String[] sootArgs = {
-				// "-whole-program",
-				"-app",
+				"-whole-program",
+				// "-app",
 				"-allow-phantom-refs",
 				"-keep-bytecode-offset",
 				"-keep-offset",
-				"-soot-classpath", cp, "-prepend-classpath",
+				"-soot-classpath", cp, 
+				//"-prepend-classpath",
 				"-keep-line-number",
 				"-main-class", args[3],
 				"-process-dir", dir,
@@ -44,25 +46,33 @@ public class GetSootArgs {
 				"-include", "org.apache.",
 				"-include", "org.w3c."
 		};
+		for(String s: sootArgs) {
+			System.out.print(s+" ");
+		}
+		System.out.println("");
 		return sootArgs;
 	}
 	private String[] normal(String[] args){
 		String cp = args[0] + "/jre/lib/rt.jar:" + args[0] + "/jre/lib/jce.jar";
 		String[] sootArgs = {
-//				"-whole-program",
-				"-app",
+				"-whole-program",
+				// "-app",
 				"-allow-phantom-refs",
 				"-keep-bytecode-offset",
 				"-p","cg.spark","on",
 				"-p","cg","all-reachable",
 				"-keep-offset",
-				"-soot-classpath", cp, "-prepend-classpath",
+				// "-soot-classpath", cp, //"-prepend-classpath",
 				"-keep-line-number",
 				"-main-class", args[3],
 				"-process-dir", args[2],
 				"-output-dir", args[4],
 				"-output-format", "jimple",
 		};
+		for(String s: sootArgs) {
+			System.out.print(s+" ");
+		}
+		System.out.println("");
 		return sootArgs;
 	}
 }

--- a/src/main/GetSootArgs.java
+++ b/src/main/GetSootArgs.java
@@ -30,10 +30,11 @@ public class GetSootArgs {
 		// String cp = args[0] + "/jre/lib/rt.jar:" + args[0] + "/jre/lib/jce.jar:" + dir + ":" + args[2] + "/dacapo-9.12-MR1-bach.jar";
 		String cp = dir + ":" + args[2] + "/dacapo-9.12-MR1-bach.jar";
 		String[] sootArgs = {
-				"-whole-program",
-				// "-app",
+				// "-whole-program",
+				"-app",
 				"-allow-phantom-refs",
 				"-keep-bytecode-offset",
+				"-no-bodies-for-excluded",
 				"-keep-offset",
 				"-soot-classpath", cp, 
 				//"-prepend-classpath",
@@ -43,8 +44,9 @@ public class GetSootArgs {
 				"-p", "cg", refl_log,
 				"-output-dir", args[4],
 				"-output-format", "jimple",
-				"-include", "org.apache.",
-				"-include", "org.w3c."
+				"-x", "jdk.*",
+				"-include", "org.apache.*",
+				"-include", "org.w3c.*"
 		};
 		for(String s: sootArgs) {
 			System.out.print(s+" ");

--- a/src/main/Main.java
+++ b/src/main/Main.java
@@ -79,7 +79,19 @@ public class Main {
 			}
 		}
 	}
-
+	static String transformFuncSignature(String inputString) {
+		StringBuilder finalString = new StringBuilder();
+		for(int i=1;i<inputString.length()-1;i++) {
+			if(inputString.charAt(i) == '.')
+				finalString.append('/');
+			else if(inputString.charAt(i) == ':')
+				finalString.append('.');
+			else if(inputString.charAt(i) == ' ')
+				continue;
+			else finalString.append(inputString.charAt(i));
+		}
+		return finalString.toString();
+	}
 	static void printResForJVM(HashMap<SootMethod, HashMap<ObjectNode, EscapeStatus>> summaries, String ipDir, String opDir) {
 		// Open File
 		Path p_ipDir = Paths.get(ipDir);
@@ -91,7 +103,8 @@ public class Main {
 		for (Map.Entry<SootMethod, HashMap<ObjectNode, EscapeStatus>> entry : summaries.entrySet()) {
 			SootMethod method = entry.getKey();
 			HashMap<ObjectNode, EscapeStatus> summary = entry.getValue();
-			sb.append(method.getBytecodeSignature());
+			sb.append(transformFuncSignature(method.getBytecodeSignature()));
+			sb.append(" ");
 			sb.append(GetListOfNoEscapeObjects.get(summary));
 			sb.append("\n");
 		}

--- a/src/resolver/SummaryResolver.java
+++ b/src/resolver/SummaryResolver.java
@@ -211,7 +211,8 @@ public class SummaryResolver {
 //			throw new IllegalArgumentException("the method of "+ cv.toString() + " doesn't have a ptg defined!");
 		}
 		if (cv.object.equals(new ObjectNode(0, ObjectType.returnValue))) {
-			c.addAll(ptg.vars.get(RetLocal.getInstance()));
+			if (ptg.vars.get(RetLocal.getInstance()) != null)
+				c.addAll(ptg.vars.get(RetLocal.getInstance()));
 		} else {
 			c.add(cv.object);
 		}

--- a/src/resolver/SummaryResolver.java
+++ b/src/resolver/SummaryResolver.java
@@ -11,11 +11,12 @@ import soot.SootMethod;
 import java.util.*;
 
 public class SummaryResolver {
-	public HashMap<SootMethod, HashMap<ObjectNode, EscapeStatus>> existingSummaries, solvedSummaries;
+	public Map<SootMethod, HashMap<ObjectNode, EscapeStatus>> existingSummaries;
+	public HashMap<SootMethod, HashMap<ObjectNode, EscapeStatus>> solvedSummaries;
 	HashMap<SootMethod, HashMap<ObjectNode, ResolutionStatus>> resolutionStatus;
-	HashMap<SootMethod, PointsToGraph> ptgs;
+	Map<SootMethod, PointsToGraph> ptgs;
 
-	private void init(HashMap<SootMethod, HashMap<ObjectNode, EscapeStatus>> existingSummaries) {
+	private void init(Map<SootMethod, HashMap<ObjectNode, EscapeStatus>> existingSummaries) {
 		this.existingSummaries = existingSummaries;
 		resolutionStatus = new HashMap<SootMethod, HashMap<ObjectNode, ResolutionStatus>>();
 		this.solvedSummaries = new HashMap<>();
@@ -33,8 +34,8 @@ public class SummaryResolver {
 
 	}
 
-	public void resolve(HashMap<SootMethod, HashMap<ObjectNode, EscapeStatus>> existingSummaries,
-						HashMap<SootMethod, PointsToGraph> ptgs) {
+	public void resolve(Map<SootMethod, HashMap<ObjectNode, EscapeStatus>> existingSummaries,
+						Map<SootMethod, PointsToGraph> ptgs) {
 		init(existingSummaries);
 		this.ptgs = ptgs;
 		//			System.out.println("--- <"+method.toString()+"> ---");

--- a/src/utils/GetListOfNoEscapeObjects.java
+++ b/src/utils/GetListOfNoEscapeObjects.java
@@ -2,6 +2,7 @@ package utils;
 
 import es.EscapeStatus;
 import ptg.ObjectNode;
+import ptg.ObjectType;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,6 +14,8 @@ public class GetListOfNoEscapeObjects {
 		ArrayList<Integer> arr = new ArrayList<>();
 		for (Map.Entry<ObjectNode, EscapeStatus> entry : summary.entrySet()) {
 			ObjectNode obj = entry.getKey();
+			if(obj.type != ObjectType.internal)
+				continue;
 			EscapeStatus es = entry.getValue();
 			if (es.containsNoEscape()) arr.add(obj.ref);
 		}

--- a/src/utils/Stats.java
+++ b/src/utils/Stats.java
@@ -16,7 +16,7 @@ public class Stats {
 	double percentageNE;
 	double percentageCV;
 
-	public Stats(HashMap<SootMethod, HashMap<ObjectNode, EscapeStatus>> summaries) {
+	public Stats(Map<SootMethod, HashMap<ObjectNode, EscapeStatus>> summaries) {
 		internal = 0;
 		noEscape = 0;
 		cv = 0;

--- a/src/utils/getBCI.java
+++ b/src/utils/getBCI.java
@@ -22,8 +22,19 @@ public class getBCI {
 			Do We need to include JNew in this?
 		*/
 		for(ValueBox ub: u.getUseBoxes() ) {
+			/*
+				This loop is to get the BCI specifically in the case of JNewArrayExpr and JNewMultiArrayExpr.
+				Each Unit in soot is constructed of multiple sub-Units. So, we reverse engineer the problematic
+				statements. We were getting problems only in AssignStmts and we need to get BCI of statement
+				on the right side of "=". This below line filters only the right side of a Assignment Statement.
+			*/
 			if(!ub.getClass().toString().equals("class soot.jimple.internal.JAssignStmt$LinkedRValueBox"))
-                continue;
+				continue;
+				
+			/*
+				 Next get the value contained in this box. If this value if a New Array/MultiArray Expr only
+				 then we need to move further.
+			 */
             Value v = ub.getValue();
             if(v==null)
                 continue;
@@ -31,6 +42,12 @@ public class getBCI {
                 ;
 			else continue;
 
+			/*
+				Actually BCI is linked to each box rather than the Unit. Because multiple statements in the
+				Java classfile can be combined together to form one JimpleStatment. Now, we get the BCI of this
+				required box and return it. If this BCI is null, we can fall back to the BCI associated with 
+				the Unit.
+			*/
 			BytecodeOffsetTag tg = (BytecodeOffsetTag) ub.getTag("BytecodeOffsetTag");
 			if(tg != null)
 				return tg.getBytecodeOffset();

--- a/src/utils/getBCI.java
+++ b/src/utils/getBCI.java
@@ -1,12 +1,30 @@
 package utils;
 
 import soot.Unit;
+import soot.Value;
+import soot.ValueBox;
+import soot.jimple.internal.JNewArrayExpr;
+import soot.jimple.internal.JNewMultiArrayExpr;
 import soot.tagkit.BytecodeOffsetTag;
 import soot.tagkit.Tag;
 
 public class getBCI {
 	public static int get(Unit u) {
 		int _ret = -1;
+		for(ValueBox ub: u.getUseBoxes() ) {
+			if(!ub.getClass().toString().equals("class soot.jimple.internal.JAssignStmt$LinkedRValueBox"))
+                continue;
+            Value v = ub.getValue();
+            if(v==null)
+                continue;
+            if(v instanceof JNewArrayExpr || v instanceof JNewMultiArrayExpr )
+                ;
+			else continue;
+			BytecodeOffsetTag tg = (BytecodeOffsetTag) ub.getTag("BytecodeOffsetTag");
+			if(tg != null)
+				return tg.getBytecodeOffset();
+		}
+		
 		Tag t = u.getTag("BytecodeOffsetTag");
 		if (t == null) {
 			String error = u.toString() + " doesn't have bytecodeoffset!";

--- a/src/utils/getBCI.java
+++ b/src/utils/getBCI.java
@@ -11,6 +11,16 @@ import soot.tagkit.Tag;
 public class getBCI {
 	public static int get(Unit u) {
 		int _ret = -1;
+
+		/*
+			We are splitting the unit into "boxes" and for semi-boxes we check if any one of 
+			them is JNewArray ot JNewMultiArray, then return BCI of the expression.
+
+			I don't know if this will always work. It is based on the data I got by printing
+			a lot of stuff. 
+
+			Do We need to include JNew in this?
+		*/
 		for(ValueBox ub: u.getUseBoxes() ) {
 			if(!ub.getClass().toString().equals("class soot.jimple.internal.JAssignStmt$LinkedRValueBox"))
                 continue;
@@ -20,6 +30,7 @@ public class getBCI {
             if(v instanceof JNewArrayExpr || v instanceof JNewMultiArrayExpr )
                 ;
 			else continue;
+
 			BytecodeOffsetTag tg = (BytecodeOffsetTag) ub.getTag("BytecodeOffsetTag");
 			if(tg != null)
 				return tg.getBytecodeOffset();

--- a/src/utils/getBCI.java
+++ b/src/utils/getBCI.java
@@ -26,30 +26,30 @@ public class getBCI {
 				This loop is to get the BCI specifically in the case of JNewArrayExpr and JNewMultiArrayExpr.
 				Each Unit in soot is constructed of multiple sub-Units. So, we reverse engineer the problematic
 				statements. We were getting problems only in AssignStmts and we need to get BCI of statement
-				on the right side of "=". This below line filters only the right side of a Assignment Statement.
+				on the right side of "=". This below line filters only the right side of an Assignment Statement.
 			*/
-			if(!ub.getClass().toString().equals("class soot.jimple.internal.JAssignStmt$LinkedRValueBox"))
+			if ( !ub.getClass().toString().equals("class soot.jimple.internal.JAssignStmt$LinkedRValueBox") )
 				continue;
 				
 			/*
-				 Next get the value contained in this box. If this value if a New Array/MultiArray Expr only
-				 then we need to move further.
+				Next get the value contained in this box. If this value is a New Array/MultiArray Expr only
+				then we need to move further.
 			 */
             Value v = ub.getValue();
-            if(v==null)
+            if (v == null)
                 continue;
-            if(v instanceof JNewArrayExpr || v instanceof JNewMultiArrayExpr )
-                ;
-			else continue;
+            if ( ! (v instanceof JNewArrayExpr || v instanceof JNewMultiArrayExpr ) )
+                continue;
 
 			/*
-				Actually BCI is linked to each box rather than the Unit. Because multiple statements in the
-				Java classfile can be combined together to form one JimpleStatment. Now, we get the BCI of this
+				Because multiple statements in the Java classfile can be combined together to form 
+				one JimpleStatment, BCI is linked to each box rather than the Unit. BCI of a Unit is 
+				the BCI of last box processed in the Unit. Now, we get the BCI of this
 				required box and return it. If this BCI is null, we can fall back to the BCI associated with 
 				the Unit.
 			*/
 			BytecodeOffsetTag tg = (BytecodeOffsetTag) ub.getTag("BytecodeOffsetTag");
-			if(tg != null)
+			if (tg != null)
 				return tg.getBytecodeOffset();
 		}
 		


### PR DESCRIPTION
Major Changes:
1. Use Correct BCI for New Array and New MultiArray Statements.
2. Change Output Format
3. Print only Internal object types.
4. Fix Dacapo issues ( don't analyse JDK and fix Null/ OutofBounds errors. )